### PR TITLE
Fix a visual bug on dashboard in the Darksend panel

### DIFF
--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -346,7 +346,6 @@ void OverviewPage::updateDarksendProgress()
         ui->darksendProgress->setValue(0);
         ui->darksendProgress->setToolTip(tr("No inputs detected"));
         // when balance is zero just show info from settings
-        strAnonymizeBuysellcoinAmount = strAnonymizeBuysellcoinAmount.remove(strAnonymizeBuysellcoinAmount.indexOf("."), BitcoinUnits::decimals(nDisplayUnit) + 1);
         strAmountAndRounds = strAnonymizeBuysellcoinAmount + " / " + tr("%n Rounds", "", nDarksendRounds);
 
         ui->labelAmountRounds->setToolTip(tr("No inputs detected"));
@@ -382,7 +381,6 @@ void OverviewPage::updateDarksendProgress()
     if(nMaxToAnonymize >= nAnonymizeBuysellcoinAmount * COIN) {
         ui->labelAmountRounds->setToolTip(tr("Found enough compatible inputs to anonymize %1")
                                           .arg(strAnonymizeBuysellcoinAmount));
-        strAnonymizeBuysellcoinAmount = strAnonymizeBuysellcoinAmount.remove(strAnonymizeBuysellcoinAmount.indexOf("."), BitcoinUnits::decimals(nDisplayUnit) + 1);
         strAmountAndRounds = strAnonymizeBuysellcoinAmount + " / " + tr("%n Rounds", "", nDarksendRounds);
     } else {
         QString strMaxToAnonymize = BitcoinUnits::formatHtmlWithUnit(nDisplayUnit, nMaxToAnonymize, false, BitcoinUnits::separatorAlways);


### PR DESCRIPTION
The field "Amounts and Rounds" display a BULL value, from a string variable using the number of digits specified in settings.
The code was incorrectly assuming this value to be a string containing all decimal digits, and was trying to remove all theses digits, leading to the removal too many characters.
This commit removes the character deletion.

----
Concretely, it fixes the "/span>" displayed on the Dashboard.
